### PR TITLE
fix outdated URL for bencode-go and go-nat-pmp

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"log"
 
-	bencode "code.google.com/p/bencode-go"
+	bencode "github.com/jackpal/bencode-go"
 )
 
 const (

--- a/natpmp.go
+++ b/natpmp.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	natpmp "code.google.com/p/go-nat-pmp"
+	natpmp "github.com/jackpal/go-nat-pmp"
 	"fmt"
 	"net"
 )

--- a/pex.go
+++ b/pex.go
@@ -7,7 +7,7 @@ import (
 	"log"
 	"time"
 
-	bencode "code.google.com/p/bencode-go"
+	bencode "github.com/jackpal/bencode-go"
 	"github.com/nictuku/nettools"
 )
 


### PR DESCRIPTION
those repositories have moved
